### PR TITLE
support additional data in custom scans

### DIFF
--- a/profile_bluesky/startup/10-devices.py
+++ b/profile_bluesky/startup/10-devices.py
@@ -7,6 +7,31 @@ print(__file__)
 MONO_FEEDBACK_OFF, MONO_FEEDBACK_ON = range(2)
 
 
+def addDeviceDataAsStream(devices, label):
+    """
+    add an ophyd Device as an addtional document stream
+    
+    Use this within a custom plan, such as this example::
+
+        yield from bps.open_run()
+        # ...
+        yield from addDeviceStream(prescanDeviceList, "metadata_prescan")
+        # ...
+        yield from custom_scan_procedure()
+        # ...
+        yield from addDeviceStream(postscanDeviceList, "metadata_postscan")
+        # ...
+        yield from bps.close_run()
+
+    """
+    yield from bps.create(name=label)
+    if isinstance(devices, Device):     # just in case...
+        devices = [devices]
+    for d in devices:
+        yield from bps.read(d)
+    yield from bps.save()
+
+
 class DCM_Feedback(Device):
     """
     monochromator EPID-record-based feedback program: fb_epid

--- a/profile_bluesky/startup/32-usaxs_flyscan.py
+++ b/profile_bluesky/startup/32-usaxs_flyscan.py
@@ -185,10 +185,7 @@ class UsaxsFlyScanDevice(Device):
             )
 
         # add an event with our MCA data in the "mca" stream
-        yield from bps.create(name="mca")
-        for d in [struck.mca1, struck.mca2, struck.mca3]:
-            yield from bps.read(d)
-        yield from bps.save()
+        yield from addDeviceDataAsStream([struck.mca1, struck.mca2, struck.mca3], "mca")
 
         logger.debug("after return", time.time() - self.t0)
         yield from user_data.set_state_plan("fly scan finished")

--- a/profile_bluesky/startup/50-plans.py
+++ b/profile_bluesky/startup/50-plans.py
@@ -86,31 +86,6 @@ def preUSAXStune(md={}):
     )
 
 
-def addDeviceStream(devices, label):
-    """
-    add an ophyd Device as an addtional document stream
-    
-    Use this within a custom plan, such as this example::
-
-        yield from bps.open_run()
-        # ...
-        yield from addDeviceStream(prescanDeviceList, "metadata_prescan")
-        # ...
-        yield from custom_scan_procedure()
-        # ...
-        yield from addDeviceStream(postscanDeviceList, "metadata_postscan")
-        # ...
-        yield from bps.close_run()
-
-    """
-    yield from bps.create(name=label)
-    if isinstance(devices, Device):     # just in case...
-        devices = [devices]
-    for d in devices:
-        yield from bps.read(d)
-    yield from bps.save()
-
-
 def Flyscan(pos_X, pos_Y, thickness, scan_title, md={}):
     """
     do one USAXS Fly Scan


### PR DESCRIPTION
While #153 described this as *metadata*, the intent was to record additional data as either [baseline](https://blueskyproject.io/bluesky/tutorial.html?highlight=baseline#choose-baseline-devices) (in the [bluesky sense](https://blueskyproject.io/bluesky/tutorial.html?highlight=baseline#baseline-readings-and-other-supplemental-data) at beginning and end of collection) or additional streams (*ad hoc* during data collection) using [`create`](https://blueskyproject.io/bluesky/generated/bluesky.plan_stubs.create.html#bluesky.plan_stubs.create), [`read`](https://blueskyproject.io/bluesky/generated/bluesky.plan_stubs.read.html) and [`save`](https://blueskyproject.io/bluesky/generated/bluesky.plan_stubs.save.html).  This PR satisfies that latter intent.