### PR TITLE
create a run showing the commands from a command list

### DIFF
--- a/profile_bluesky/startup/instrument/plans/__init__.py
+++ b/profile_bluesky/startup/instrument/plans/__init__.py
@@ -9,6 +9,7 @@ syntax or passed to the bluesky RunEngine such as ``RE(plan())``.
 from .area_detector import *
 from .axis_tuning import *
 from .command_list import *
+from .doc_run import *
 from .filters import *
 from .mode_changes import *
 from .mono_feedback import *

--- a/profile_bluesky/startup/instrument/plans/command_list.py
+++ b/profile_bluesky/startup/instrument/plans/command_list.py
@@ -42,6 +42,7 @@ from ..utils.quoted_line import split_quoted_line
 from .axis_tuning import instrument_default_tune_ranges
 from .axis_tuning import update_EPICS_tuning_widths
 from .axis_tuning import user_defined_settings
+from .doc_run import documentation_run
 from .mode_changes import mode_SAXS, mode_USAXS, mode_WAXS, mode_Radiography
 
 
@@ -393,8 +394,10 @@ def execute_command_list(filename, commands, md={}):
     text += str(command_list_as_table(commands))
     logger.info(text)
 
-    # TODO: save the command list as a separate Bluesky run for documentation purposes
-    archive = instrument_archive(text)
+    # save the command list as a separate Bluesky run for documentation purposes
+    yield from documentation_run(text)
+
+    instrument_archive(text)
 
     yield from before_command_list(md=md, commands=commands)
     for command in commands:

--- a/profile_bluesky/startup/instrument/plans/doc_run.py
+++ b/profile_bluesky/startup/instrument/plans/doc_run.py
@@ -1,6 +1,6 @@
 
 """
-Read an object and create a run.
+Save text as a bluesky run.
 """
 
 __all__ = [
@@ -10,22 +10,29 @@ __all__ = [
 from ..session_logs import logger
 logger.info(__file__)
 
+from ..framework import bec
 from bluesky import plan_stubs as bps
+from ophyd import Signal
 
 
-def documentation_run(obj, md=None, stream=None):
+def documentation_run(words, md=None, stream=None):
     """
-    Read an object and save as a bluesky run.
+    Save text as a bluesky run.
     """
+    text = Signal(value=words, name="text")
     stream = stream or "primary"
     _md = dict(
-        purpose=f"document current values of device {obj.name}",
+        purpose=f"save text as bluesky run",
         plan_name="documentation_run",
     )
     _md.update(md or {})
+    bec.disable_plots()
+    bec.disable_table()
     uid = yield from bps.open_run(md=_md)
     yield from bps.create(stream)
-    yield from bps.read(obj)
+    yield from bps.read(text)
     yield from bps.save()
     yield from bps.close_run()
+    bec.enable_table()
+    bec.enable_plots()
     return uid

--- a/profile_bluesky/startup/instrument/plans/doc_run.py
+++ b/profile_bluesky/startup/instrument/plans/doc_run.py
@@ -1,0 +1,31 @@
+
+"""
+Read an object and create a run.
+"""
+
+__all__ = [
+    "documentation_run", 
+    ]
+
+from ..session_logs import logger
+logger.info(__file__)
+
+from bluesky import plan_stubs as bps
+
+
+def documentation_run(obj, md=None, stream=None):
+    """
+    Read an object and save as a bluesky run.
+    """
+    stream = stream or "primary"
+    _md = dict(
+        purpose=f"document current values of device {obj.name}",
+        plan_name="documentation_run",
+    )
+    _md.update(md or {})
+    uid = yield from bps.open_run(md=_md)
+    yield from bps.create(stream)
+    yield from bps.read(obj)
+    yield from bps.save()
+    yield from bps.close_run()
+    return uid


### PR DESCRIPTION
fixes #370

Instead of adding lots of information to the metadata of every run resulting from a command list, document the command list itself as the data of a separate run.