### PR TITLE
order numbers are specific to each scan technique

### DIFF
--- a/profile_bluesky/startup/instrument/plans/sample_imaging.py
+++ b/profile_bluesky/startup/instrument/plans/sample_imaging.py
@@ -34,12 +34,22 @@ def record_sample_image_on_demand(technique_name, title, _md):
     if blackfly_optical.should_save_jpeg:
         det = blackfly_optical  # define once here, in case it ever changes
         path = techniqueSubdirectory(technique_name)
+
+        xref = dict(
+            usaxs = terms.FlyScan.order_number,
+            saxs = saxs_det.hdf1.file_number,
+            waxs = waxs_det.hdf1.file_number,
+        )
+        order_number = xref.get(technique_name, xref["usaxs"]).get()
+        if technique_name == "usaxs":
+            order_number -= 1
+
         yield from bps.mv(
             det.jpeg1.file_path,
             "/mnt" + os.path.abspath(path) + "/",  # MUST end with "/"
 
             det.jpeg1.file_name, title,
-            det.jpeg1.file_number, terms.FlyScan.order_number.get()-1,
+            det.jpeg1.file_number, order_number,
             )
 
         yield from det.take_image()

--- a/profile_bluesky/startup/instrument/plans/scans.py
+++ b/profile_bluesky/startup/instrument/plans/scans.py
@@ -335,8 +335,8 @@ def USAXSscanStep(pos_X, pos_Y, thickness, scan_title, md=None):
     yield from user_data.set_state_plan("Running USAXS step scan")
 
     SCAN_N = RE.md["scan_id"]+1     # update with next number
+    yield from bps.mvr(terms.FlyScan.order_number, 1)  # increment it
     yield from bps.mv(
-        terms.FlyScan.order_number, terms.FlyScan.order_number.get() + 1,  # increment it
         user_data.scanning, "scanning",          # we are scanning now (or will be very soon)
         user_data.spec_scan, str(SCAN_N),
     )
@@ -554,8 +554,8 @@ def Flyscan(pos_X, pos_Y, thickness, scan_title, md=None):
     )
 
     SCAN_N = RE.md["scan_id"]+1     # update with next number
+    yield from bps.mvr(terms.FlyScan.order_number, 1)  # increment it
     yield from bps.mv(
-        terms.FlyScan.order_number, terms.FlyScan.order_number.get() + 1,  # increment it
         user_data.scanning, "scanning",          # we are scanning now (or will be very soon)
         user_data.spec_scan, str(SCAN_N),
     )


### PR DESCRIPTION
The *order number* is written into the data file name for each technique and for the associated sample image.

Ensure the numbers are coordinated at the start of a set of samples and that they increment properly for each scan technique.

fixes #396 and fixes #398