### PR TITLE
Set default timeout on EpicsSignalBase

### DIFF
--- a/profile_bluesky/startup/instrument/framework/initialize.py
+++ b/profile_bluesky/startup/instrument/framework/initialize.py
@@ -121,4 +121,5 @@ from bluesky.simulators import summarize_plan
 
 # set default timeout for all EpicsSignal connections & communications
 import ophyd
-ophyd.EpicsSignal.set_default_timeout(timeout=10, connection_timeout=5)
+from ophyd.signal import EpicsSignalBase
+EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=5)


### PR DESCRIPTION
Set default timeout on [`EpicsSignalBase`](https://github.com/bluesky/ophyd/issues/917)

MNT #417